### PR TITLE
translations for quick replies

### DIFF
--- a/src/translate.js
+++ b/src/translate.js
@@ -43,7 +43,8 @@ module.exports = (languageResolver, options) => {
         const lang = languageResolver(req);
         return getTranslator(lang).then((translator) => {
             Object.assign(res, {
-                t: translator
+                t: translator,
+                tq: translator
             });
             return Router.CONTINUE;
         });


### PR DESCRIPTION
current translation crawler does not support quick replies from all places, this is temporary fix or precedence of quick replies translations. The crawler would be too complex without and change would be too time--consuming